### PR TITLE
fix: replace hardcoded root.hcl with RootFileName template variable in boilerplate

### DIFF
--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -21,7 +21,7 @@ locals {
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
 generate "provider-mongoatlas" {


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"root.hcl"` string in the `find_in_parent_folders` call with the boilerplate template variable `{{ .RootFileName }}`
- Makes the root HCL filename configurable at boilerplate render time
- Aligns with the rest of the template expressions already used throughout the file (e.g. `{{ .sourceUrl }}`, `{{ .is_hub }}`, etc.)

## Test plan

- [ ] Verify `make fmt` passes with no changes
- [ ] Verify `make lint` passes cleanly
- [ ] Confirm boilerplate render produces the correct `find_in_parent_folders` call with the configured root filename

+semver: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)